### PR TITLE
Update CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+* text=auto eol=lf
+
+*.conf text eol=lf
+*.html text eol=lf
+*.ini text eol=lf
+*.js text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.php text eol=lf
+*.sh text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+composer.lock text eol=lf merge=ours
+
+*.ico binary
+*.png binary

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,22 +23,18 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php: ['8.0', '8.1', '8.2', '8.3', '8.4']
-                symfony_version: ['5.4.*', '6.0.*', '6.1.*', '6.2.*' , '6.3.*', '6.4.*', '7.0.*']
+                php: ['8.1', '8.2', '8.3', '8.4']
+                symfony_version: ['6.4.*', '7.0.*', '7.1.*', '7.2.*', '7.3.*']
                 composer-flags: ['--prefer-stable']
                 exclude:
-                    - php: '8.0'
-                      symfony_version: '6.1.*' # Requires PHP >= 8.1 for compatibility
-                    - php: '8.0'
-                      symfony_version: '6.2.*' # Requires PHP >= 8.1 for compatibility
-                    - php: '8.0'
-                      symfony_version: '6.3.*' # Requires PHP >= 8.1 for compatibility
-                    - php: '8.0'
-                      symfony_version: '6.4.*' # Requires PHP >= 8.1 for compatibility
-                    - php: '8.0'
-                      symfony_version: '7.0.*' # Requires PHP >= 8.2 for compatibility
                     - php: '8.1'
                       symfony_version: '7.0.*' # Requires PHP >= 8.2 for compatibility
+                    - php: '8.1'
+                      symfony_version: '7.1.*' # Requires PHP >= 8.2 for compatibility
+                    - php: '8.1'
+                      symfony_version: '7.2.*' # Requires PHP >= 8.2 for compatibility
+                    - php: '8.1'
+                      symfony_version: '7.3.*' # Requires PHP >= 8.2 for compatibility
         steps:
             -   uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php: ['8.0', '8.1', '8.2', '8.3']
+                php: ['8.0', '8.1', '8.2', '8.3', '8.4']
                 symfony_version: ['5.4.*', '6.0.*', '6.1.*', '6.2.*' , '6.3.*', '6.4.*', '7.0.*']
                 composer-flags: ['--prefer-stable']
                 exclude:

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
         "php-parallel-lint/php-parallel-lint": "^1.3",
         "phpro/grumphp": "^1.13 || ^2.4",
         "phpunit/phpunit": "^9.5.22",
-        "roave/security-advisories": "dev-latest",
         "symfony/var-dumper": "^5.4 || ^6.0 || ^7.0",
         "symplify/coding-standard": "^12.0",
         "symplify/easy-coding-standard": "^12.0"

--- a/composer.json
+++ b/composer.json
@@ -4,18 +4,18 @@
     "license": "MIT",
     "type": "composer-plugin",
     "require": {
-        "php": ">=8.0",
+        "php": ">=8.1",
         "ext-json": "*",
         "composer-plugin-api": "^2.3",
         "colinodell/indentation": "^1.0",
-        "symfony/config": "^5.4 || ^6.0 || ^7.0",
-        "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
-        "symfony/filesystem": "^5.4 || ^6.0 || ^7.0",
-        "symfony/finder": "^5.4 || ^6.0 || ^7.0",
-        "symfony/options-resolver": "^5.4 || ^6.0 || ^7.0",
-        "symfony/validator": "^5.4 || ^6.0 || ^7.0",
-        "symfony/var-exporter": "^5.4 || ^6.0 || ^7.0",
-        "symfony/yaml": "^5.4 || ^6.0 || ^7.0"
+        "symfony/config": "^6.4 || ^7.0",
+        "symfony/dependency-injection": "^6.4 || ^7.0",
+        "symfony/filesystem": "^6.4 || ^7.0",
+        "symfony/finder": "^6.4 || ^7.0",
+        "symfony/options-resolver": "^6.4 || ^7.0",
+        "symfony/validator": "^6.4 || ^7.0",
+        "symfony/var-exporter": "^6.4 || ^7.0",
+        "symfony/yaml": "^6.4 || ^7.0"
     },
     "require-dev": {
         "composer/composer": "^2.3",
@@ -26,7 +26,7 @@
         "php-parallel-lint/php-parallel-lint": "^1.3",
         "phpro/grumphp": "^1.13 || ^2.4",
         "phpunit/phpunit": "^9.5.22",
-        "symfony/var-dumper": "^5.4 || ^6.0 || ^7.0",
+        "symfony/var-dumper": "^6.4 || ^7.0",
         "symplify/coding-standard": "^12.0",
         "symplify/easy-coding-standard": "^12.0"
     },

--- a/ecs.php
+++ b/ecs.php
@@ -52,7 +52,6 @@ return static function (ECSConfig $ecsConfig): void {
 
     ]);
 
-    $ecsConfig->rule(NativeFunctionInvocationFixer::class);
     $ecsConfig->rule(NoTrailingCommaInSinglelineFixer::class);
     $ecsConfig->rule(TrailingCommaInMultilineFixer::class);
     $ecsConfig->rule(MethodChainingNewlineFixer::class);


### PR DESCRIPTION
Removed roave/security-advisories which break the CI, as it doesn't allow a large range of symfony components in certain minor versions.